### PR TITLE
Refactor references to simplify editing

### DIFF
--- a/audit-checklists/ERC-4337.md
+++ b/audit-checklists/ERC-4337.md
@@ -4,56 +4,56 @@
 
 ### General
 
-- [x] How are the audited contracts different from Infinitism's sample contracts? [[1]](https://github.com/eth-infinitism/account-abstraction/tree/v0.6.0/contracts/samples)
+- [x] How are the audited contracts different from [Infinitism's sample contracts](https://github.com/eth-infinitism/account-abstraction/tree/v0.6.0/contracts/samples)?
 - [x] Can the project be deployed on targeted EVM-compatible chains, e.g. through the correct version of the Solidity compiler?
-  - Code4rena/Ambire/M-04: Project may fail to be deployed to chains not compatible with Shanghai hardfork [[2]](https://code4rena.com/reports/2023-05-ambire#m-04-project-may-fail-to-be-deployed-to-chains-not-compatible-with-shanghai-hardfork)
-  - Non-issue in Infinitism sample: [[3]](https://github.com/eth-infinitism/account-abstraction/blob/v0.6.0/contracts/samples/SimpleAccount.sol#L2)
+  - [Code4rena/Ambire/M-04: Project may fail to be deployed to chains not compatible with Shanghai hardfork](https://code4rena.com/reports/2023-05-ambire#m-04-project-may-fail-to-be-deployed-to-chains-not-compatible-with-shanghai-hardfork)
+  - [Non-issue in Infinitism sample](https://github.com/eth-infinitism/account-abstraction/blob/v0.6.0/contracts/samples/SimpleAccount.sol#L2)
 
 ### Wallet Account Factory
 
 - [x] Does it use CREATE2 to create the wallet?
-  - ERC-4337: The factory is expected to use CREATE2 (not CREATE) to create the wallet [[4]](https://eips.ethereum.org/EIPS/eip-4337#first-time-account-creation)
-  - Non-issue in Infinitism sample: [[5]](https://github.com/eth-infinitism/account-abstraction/blob/v0.6.0/contracts/samples/SimpleAccountFactory.sol#L44)
+  - [ERC-4337: The factory is expected to use CREATE2 (not CREATE) to create the wallet](https://eips.ethereum.org/EIPS/eip-4337#first-time-account-creation)
+  - [Non-issue in Infinitism sample](https://github.com/eth-infinitism/account-abstraction/blob/v0.6.0/contracts/samples/SimpleAccountFactory.sol#L44)
 - [x] Does it return the wallet account address even if it has already been created?
-  - ERC-4337: If the factory does use CREATE2 or some other deterministic method to create the wallet, it’s expected to return the wallet address even if the wallet has already been created. [[4]](https://eips.ethereum.org/EIPS/eip-4337#first-time-account-creation)
-  - Non-issue in Infinitism sample: [[6]](https://github.com/eth-infinitism/account-abstraction/blob/v0.6.0/contracts/samples/SimpleAccountFactory.sol#L32)
+  - [ERC-4337: If the factory does use CREATE2 or some other deterministic method to create the wallet, it’s expected to return the wallet address even if the wallet has already been created.](https://eips.ethereum.org/EIPS/eip-4337#first-time-account-creation)
+  - [Non-issue in Infinitism sample](https://github.com/eth-infinitism/account-abstraction/blob/v0.6.0/contracts/samples/SimpleAccountFactory.sol#L32)
 - [x] Can an attacker gain control of the wallet account by deploying it on behalf of its owner?
-  - ERC-4337: For security reasons, it is important that the generated contract address will depend on the initial signature. This way, even if someone can create a wallet at that address, he can’t set different credentials to control it. [[4]](https://eips.ethereum.org/EIPS/eip-4337#first-time-account-creation)
-  - Code4rena/Biconomy/H-03: Attacker can gain control of counterfactual wallet [[7]](https://code4rena.com/reports/2023-01-biconomy#h-03-attacker-can-gain-control-of-counterfactual-wallet)
-  - Code4rena/Ambire/L-01: `AmbireAccountFactory.deploySafe()` does not guarantee that no call hasn’t already been made on the deployed contract [[8]](https://code4rena.com/reports/2023-05-ambire#l-01-ambireaccountfactorydeploysafe-does-not-guarantee-that-no-call-hasnt-already-been-made-on-the-deployed-contract)
-  - Non-issue in Infinitism sample: [[9]](https://github.com/eth-infinitism/account-abstraction/blob/v0.6.0/contracts/samples/SimpleAccountFactory.sol#L29)
+  - [ERC-4337: For security reasons, it is important that the generated contract address will depend on the initial signature. This way, even if someone can create a wallet at that address, he can’t set different credentials to control it.](https://eips.ethereum.org/EIPS/eip-4337#first-time-account-creation)
+  - [Code4rena/Biconomy/H-03: Attacker can gain control of counterfactual wallet](https://code4rena.com/reports/2023-01-biconomy#h-03-attacker-can-gain-control-of-counterfactual-wallet)
+  - [Code4rena/Ambire/L-01: `AmbireAccountFactory.deploySafe()` does not guarantee that no call hasn’t already been made on the deployed contract](https://code4rena.com/reports/2023-05-ambire#l-01-ambireaccountfactorydeploysafe-does-not-guarantee-that-no-call-hasnt-already-been-made-on-the-deployed-contract)
+  - [Non-issue in Infinitism sample](https://github.com/eth-infinitism/account-abstraction/blob/v0.6.0/contracts/samples/SimpleAccountFactory.sol#L29)
 
 ### Wallet Account
 
 - [x] Can the wallet account implementation contract be initialized by an attacker, e.g. through frontrunning?
-  - Code4rena/Biconomy/H-01: Destruction of the SmartAccount implementation [[10]](https://code4rena.com/reports/2023-01-biconomy#h-01-destruction-of-the-smartaccount-implementation)
-  - Code4rena/Ambire/M-05: AmbireAccount implementation can be destroyed by privileges [[11]](https://code4rena.com/reports/2023-05-ambire#m-05-ambireaccount-implementation-can-be-destroyed-by-privileges)
-  - Non-issue in Infinitism sample: [[12]](https://github.com/eth-infinitism/account-abstraction/blob/v0.6.0/contracts/samples/SimpleAccount.sol#L46)
+  - [Code4rena/Biconomy/H-01: Destruction of the SmartAccount implementation](https://code4rena.com/reports/2023-01-biconomy#h-01-destruction-of-the-smartaccount-implementation)
+  - [Code4rena/Ambire/M-05: AmbireAccount implementation can be destroyed by privileges](https://code4rena.com/reports/2023-05-ambire#m-05-ambireaccount-implementation-can-be-destroyed-by-privileges)
+  - [Non-issue in Infinitism sample](https://github.com/eth-infinitism/account-abstraction/blob/v0.6.0/contracts/samples/SimpleAccount.sol#L46)
 - [x] Can the wallet account execute transactions without going through the EntryPoint, and if so, are access controls and signature validations properly implemented?
-  - Code4rena/Biconomy/H-04: Arbitrary transactions possible due to insufficient signature validation [[13]](https://code4rena.com/reports/2023-01-biconomy#h-04-arbitrary-transactions-possible-due-to-insufficient-signature-validation)
-  - Code4rena/Ambire/M-03: Recovery transaction can be replayed after a cancellation [[14]](https://code4rena.com/reports/2023-05-ambire#m-03-recovery-transaction-can-be-replayed-after-a-cancellation)
-  - Code4rena/Ambire/L-02: Fallback handler should not be allowed to be this [[15]](https://code4rena.com/reports/2023-05-ambire#l-02-fallback-handler-should-not-be-allowed-to-be-this)
-  - Code4rena/Ambire/L-16: Transactions bundles signed for a future nonce cannot be cancelled [[16]](https://code4rena.com/reports/2023-05-ambire#l-16-transactions-bundles-signed-for-a-future-nonce-cannot-be-cancelled)
-  - ZeroDev/Kernel/ZeroDev-wallet-02: Signature Replay Attack can be done on validateUserOp of Kernel [[17]](https://github.com/zerodevapp/kernel/blob/main/audits/kalos_v1.pdf)
-  - ZeroDev/Kernel/ZeroDev-wallet-05: Incomplete Validation of Operation Types in Session Verification [[18]](https://github.com/zerodevapp/kernel/blob/main/audits/kalos_v1.pdf)
-  - Non-issue in Infinitism sample: [[19]](https://github.com/eth-infinitism/account-abstraction/blob/v0.6.0/contracts/samples/SimpleAccount.sol#L58)
+  - [Code4rena/Biconomy/H-04: Arbitrary transactions possible due to insufficient signature validation](https://code4rena.com/reports/2023-01-biconomy#h-04-arbitrary-transactions-possible-due-to-insufficient-signature-validation)
+  - [Code4rena/Ambire/M-03: Recovery transaction can be replayed after a cancellation](https://code4rena.com/reports/2023-05-ambire#m-03-recovery-transaction-can-be-replayed-after-a-cancellation)
+  - [Code4rena/Ambire/L-02: Fallback handler should not be allowed to be this](https://code4rena.com/reports/2023-05-ambire#l-02-fallback-handler-should-not-be-allowed-to-be-this)
+  - [Code4rena/Ambire/L-16: Transactions bundles signed for a future nonce cannot be cancelled](https://code4rena.com/reports/2023-05-ambire#l-16-transactions-bundles-signed-for-a-future-nonce-cannot-be-cancelled)
+  - [ZeroDev/Kernel/ZeroDev-wallet-02: Signature Replay Attack can be done on validateUserOp of Kernel](https://github.com/zerodevapp/kernel/blob/main/audits/kalos_v1.pdf)
+  - [ZeroDev/Kernel/ZeroDev-wallet-05: Incomplete Validation of Operation Types in Session Verification](https://github.com/zerodevapp/kernel/blob/main/audits/kalos_v1.pdf)
+  - [Non-issue in Infinitism sample](https://github.com/eth-infinitism/account-abstraction/blob/v0.6.0/contracts/samples/SimpleAccount.sol#L58)
 - [x] Does the wallet account use different signature validation schemes, and are they correctly implemented?
-  - ERC-4337: If the account does not support signature aggregation, it MUST validate the signature is a valid signature of the userOpHash, and SHOULD return SIG_VALIDATION_FAILED (and not revert) on signature mismatch. Any other error should revert. [[20]](https://eips.ethereum.org/EIPS/eip-4337#definitions)
-  - Code4rena/Ambire/L-03: Schnorr signature validation may be incompatible with the intended signers [[21]](https://code4rena.com/reports/2023-05-ambire#l-03-schnorr-signature-validation-may-be-incompatible-with-the-intended-signers)
-  - Code4rena/Ambire/L-04: Schnorr signature length is not checked [[22]](https://code4rena.com/reports/2023-05-ambire#l-04-schnorr-signature-length-is-not-checked)
-  - Code4rena/Ambire/L-15: `require(sp != 0);` fails to protect Schnorr signature validation
-  - Non-issue in Infinitism sample: [[23]](https://github.com/eth-infinitism/account-abstraction/blob/v0.6.0/contracts/samples/SimpleAccount.sol#L96)
+  - [ERC-4337: If the account does not support signature aggregation, it MUST validate the signature is a valid signature of the `userOpHash`, and SHOULD return `SIG_VALIDATION_FAILED` (and not revert) on signature mismatch. Any other error should revert.](https://eips.ethereum.org/EIPS/eip-4337#definitions)
+  - [Code4rena/Ambire/L-03: Schnorr signature validation may be incompatible with the intended signers](https://code4rena.com/reports/2023-05-ambire#l-03-schnorr-signature-validation-may-be-incompatible-with-the-intended-signers)
+  - [Code4rena/Ambire/L-04: Schnorr signature length is not checked](https://code4rena.com/reports/2023-05-ambire#l-04-schnorr-signature-length-is-not-checked)
+  - [Code4rena/Ambire/L-15: `require(sp != 0);` fails to protect Schnorr signature validation](https://code4rena.com/reports/2023-05-ambire#l-15-requiresp--0-fails-to-protect-schnorr-signature-validation)
+  - [Non-issue in Infinitism sample](https://github.com/eth-infinitism/account-abstraction/blob/v0.6.0/contracts/samples/SimpleAccount.sol#L96)
 - [x] Does the wallet account implement ERC-1271, and if so, can "owners" be shared between accounts?
-  - In most naive implementations of `isValidSignature()` (e.g. one that checks that *some* owner has signed the `bytes32 hash`), signatures can be replayed across accounts with shared owners. The hash needs to be altered by the account (e.g. using EIP-712) so that a signature is only valid for a specific wallet. [[24]](https://github.com/SoulWallet/soul-wallet-contract/blob/d0895e0d0990dd25f39254fee707d7898a852652/contracts/helper/SignatureValidator.sol#L18-L24)
-  - Correct implementation in safe-contracts: [[25]](https://github.com/safe-global/safe-contracts/blob/69caefcda788f2f6b0b154d50d010897560c8deb/contracts/handler/CompatibilityFallbackHandler.sol#L57-L68)
+  - In most naive implementations of `isValidSignature()` (e.g. one that checks that *some* owner has signed the `bytes32 hash`), signatures can be replayed across accounts with shared owners. The hash needs to be altered by the account (e.g. using EIP-712) so that a signature is [only valid for a specific wallet](https://github.com/SoulWallet/soul-wallet-contract/blob/d0895e0d0990dd25f39254fee707d7898a852652/contracts/helper/SignatureValidator.sol#L18-L24).
+  - [Correct implementation in Safe contracts](https://github.com/safe-global/safe-contracts/blob/69caefcda788f2f6b0b154d50d010897560c8deb/contracts/handler/CompatibilityFallbackHandler.sol#L57-L68)
 
 
 ### Paymaster
 
 - [x] Can VerifyingPaymaster signatures be replayed?
-  - Code4rena/Biconomy/H-05: Paymaster’s signature can be replayed to drain their deposits [[26]](https://code4rena.com/reports/2023-01-biconomy#h-05-paymaster-eth-can-be-drained-with-malicious-sender)
-  - Code4rena/Biconomy/M-03: Cross-Chain Signature Replay Attack [[27]](https://code4rena.com/reports/2023-01-biconomy#m-03-cross-chain-signature-replay-attack)
-  - Non-issue in Infinitism sample: [[28]](https://github.com/eth-infinitism/account-abstraction/blob/v0.6.0/contracts/samples/VerifyingPaymaster.sol#L64), [[29]](https://github.com/eth-infinitism/account-abstraction/blob/v0.6.0/contracts/samples/VerifyingPaymaster.sol#L88)
+  - [Code4rena/Biconomy/H-05: Paymaster’s signature can be replayed to drain their deposits](https://code4rena.com/reports/2023-01-biconomy#h-05-paymaster-eth-can-be-drained-with-malicious-sender)
+  - [Code4rena/Biconomy/M-03: Cross-Chain Signature Replay Attack](https://code4rena.com/reports/2023-01-biconomy#m-03-cross-chain-signature-replay-attack)
+  - [Non-issue](https://github.com/eth-infinitism/account-abstraction/blob/v0.6.0/contracts/samples/VerifyingPaymaster.sol#L64) in [Infinitism sample](https://github.com/eth-infinitism/account-abstraction/blob/v0.6.0/contracts/samples/VerifyingPaymaster.sol#L88)
 
 ## Resources
 


### PR DESCRIPTION
This PR removes number references in favor of inline references, in order to simplify the editing and contribution process.