### PR TITLE
Add obscure v0.6 `postOp()` behavior 

### DIFF
--- a/audit-checklists/ERC-4337.md
+++ b/audit-checklists/ERC-4337.md
@@ -71,6 +71,8 @@
   - [Code4rena/Biconomy/H-05: Paymaster’s signature can be replayed to drain their deposits](https://code4rena.com/reports/2023-01-biconomy#h-05-paymaster-eth-can-be-drained-with-malicious-sender)
   - [Code4rena/Biconomy/M-03: Cross-Chain Signature Replay Attack](https://code4rena.com/reports/2023-01-biconomy#m-03-cross-chain-signature-replay-attack)
   - [Non-issue](https://github.com/eth-infinitism/account-abstraction/blob/v0.6.0/contracts/samples/VerifyingPaymaster.sol#L64) in [Infinitism sample](https://github.com/eth-infinitism/account-abstraction/blob/v0.6.0/contracts/samples/VerifyingPaymaster.sol#L88)
+- [x] Can arbitrary error messages happen in the `postOp()` function?
+  - There is a [bug in the v0.6 entrypoint](https://github.com/eth-infinitism/account-abstraction/pull/293) that results in the mishandling of short revert messages. This means a revert in the initial `postOp()` call can revert the entire bundle, even though it's expected that a second `postOp()` call would be made.    
 
 ### Bundler
 


### PR DESCRIPTION
Hello @aviggiano - I recently became aware of some interesting/obscure behavior in the v0.6 entrypoint, and thought it could be useful to add to the checklist as well. WDYT?  